### PR TITLE
feat: process and ack oldest

### DIFF
--- a/internal/asynq_task_queue.go
+++ b/internal/asynq_task_queue.go
@@ -122,7 +122,11 @@ func (tq *AsynqTaskQueue[T]) ProcessAndAckOldest(ctx context.Context, fn func(co
 	if err = fn(ctx, task.Message); err != nil {
 		return err
 	}
-	return tq.Delete(ctx, taskID)
+	if err = tq.Delete(ctx, taskID); err != nil {
+		return err
+	}
+	tq.logger.Infof("processed and deleted task: ID=%s, Queue=%s", taskID, tq.queueName)
+	return nil
 }
 
 func (tq *AsynqTaskQueue[T]) mapToTask(taskInfo *asynq.TaskInfo) (task.Task[T], error) {

--- a/task_queue.go
+++ b/task_queue.go
@@ -15,6 +15,7 @@ type TaskQueue[T task.Message] interface {
 	DeleteAll(ctx context.Context) error
 	GetOldest(ctx context.Context) (task.Task[T], string, error)
 	Delete(ctx context.Context, id string) error
+	ProcessAndAckOldest(ctx context.Context, fn func(context.Context, T) error) error
 }
 
 func NewTaskQueue[T task.Message](logger ezutil.Logger, db DB) TaskQueue[T] {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to process and acknowledge the oldest pending background task in a single operation, delivering more predictable execution order and reducing queue contention.
  * Improved handling when no pending tasks are available, avoiding unnecessary work and reducing noise.
  * Enhances overall reliability of background task processing by ensuring successful tasks are immediately acknowledged, helping prevent buildup of stale or duplicate work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->